### PR TITLE
bugfix: Remove implementationOnly imports for the Xcode 16.3+ breaking change

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -3,7 +3,7 @@ import XCTest
 #if canImport(Testing)
   // NB: We are importing only the implementation of Testing because that framework is not available
   //     in Xcode UI test targets.
-  @_implementationOnly import Testing
+  import Testing
 #endif
 
 /// Enhances failure messages with a command line diff tool expression that can be copied and pasted

--- a/Sources/SnapshotTesting/Internal/RecordIssue.swift
+++ b/Sources/SnapshotTesting/Internal/RecordIssue.swift
@@ -3,7 +3,7 @@ import XCTest
 #if canImport(Testing)
   // NB: We are importing only the implementation of Testing because that framework is not available
   //     in Xcode UI test targets.
-  @_implementationOnly import Testing
+  import Testing
 #endif
 
 var isSwiftTesting: Bool {

--- a/Sources/SnapshotTesting/SnapshotTestingConfiguration.swift
+++ b/Sources/SnapshotTesting/SnapshotTestingConfiguration.swift
@@ -168,7 +168,9 @@ public struct SnapshotTestingConfiguration: Sendable {
 
     /// The [Kaleidoscope](http://kaleidoscope.app) diff tool.
     public static let ksdiff = Self {
-      "ksdiff \($0) \($1)"
+      """
+      ksdiff "\($0)" "\($1)"
+      """
     }
 
     /// The default diff tool.

--- a/Sources/SnapshotTesting/SnapshotsTestTrait.swift
+++ b/Sources/SnapshotTesting/SnapshotsTestTrait.swift
@@ -1,7 +1,7 @@
 #if canImport(Testing)
   // NB: We are importing only the implementation of Testing because that framework is not available
   //     in Xcode UI test targets.
-  @_implementationOnly import Testing
+import Testing
 
   @_spi(Experimental)
   extension Trait where Self == _SnapshotsTestTrait {


### PR DESCRIPTION
* Removes the use of `@_implementationOnly` on the Testing imports, this was breaking Xcode 16.3 and above.
* Adds quotes around `ksdiff` output to make copy/paste work with spaces in paths.